### PR TITLE
Make sure the `v` prefix in version is not needed

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,5 +1,5 @@
 #!/bin/bash
 # bin/list-all
 curl -s "https://api.github.com/repos/coreos/butane/releases" | \
-  grep -oP '"tag_name": "\K(.*)(?=")' | \
+  grep -oP '"tag_name": "v\K\d+\.\d+\.\d+' | \
   sort -V


### PR DESCRIPTION
Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>
